### PR TITLE
Implement streaming rendering

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,4 +32,5 @@ backoff = { version = "0.4.0", features = ["futures", "tokio"] }
 time = { version = "0.3", features = ["std"] }
 
 [profile.release]
+panic = "abort"
 debug = 1

--- a/ansi-to-html/src/lib.rs
+++ b/ansi-to-html/src/lib.rs
@@ -4,32 +4,32 @@ mod ansi;
 mod perform;
 mod renderer;
 
-pub struct Handle {
-    renderer: renderer::Renderer,
+pub struct Handle<W> {
+    renderer: renderer::Renderer<W>,
     parser: vte::Parser,
 }
 
-impl Handle {
-    pub fn new() -> Self {
+impl<W: Write> Handle<W> {
+    pub fn new(mut out: W) -> Self {
+        out.write_all(
+            br#"<!DOCTYPE html><html><body style="background:#111;color:#eee;"><body>
+            <pre style="word-wrap:break-word;white-space:pre-wrap;font-size:14px;font-size-adjust:none;text-size-adjust:none;-webkit-text-size-adjust:100%;-moz-text-size-adjust:100%;-ms-text-size-adjust:100%;"></style>"#
+        ).unwrap();
         Self {
-            renderer: renderer::Renderer::new(String::new()),
+            renderer: renderer::Renderer::new(out, String::new()),
             parser: vte::Parser::new(),
         }
     }
 
-    pub fn finish<F: Write>(&self, mut output: F) -> std::io::Result<()> {
-        output.write_all(
-            br#"<!DOCTYPE html><html><body style="background:#111;color:#eee;"><body>
-            <pre style="word-wrap:break-word;white-space:pre-wrap;font-size:14px;font-size-adjust:none;text-size-adjust:none;-webkit-text-size-adjust:100%;-moz-text-size-adjust:100%;-ms-text-size-adjust:100%;"></style>"#
-        )?;
-        self.renderer.emit_html(&mut output)?;
-        output.write_all(b"</pre></body><style>")?;
-        self.renderer.emit_css(&mut output)?;
-        output.write_all(b"</style></html>")
+    pub fn finish(&mut self) -> std::io::Result<()> {
+        self.renderer.emit_html()?;
+        self.renderer.out.write_all(b"</pre></body><style>")?;
+        self.renderer.emit_css()?;
+        self.renderer.out.write_all(b"</style></html>")
     }
 }
 
-impl Write for Handle {
+impl<W: Write> Write for Handle<W> {
     fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
         for b in buf {
             self.parser.advance(&mut self.renderer, *b);
@@ -43,15 +43,17 @@ impl Write for Handle {
 }
 
 pub fn render(name: String, bytes: &[u8]) -> (String, String) {
-    let mut h = Handle {
-        renderer: renderer::Renderer::new(name),
+    let mut html = Vec::new();
+    let mut handle = Handle {
+        renderer: renderer::Renderer::new(&mut html, name),
         parser: vte::Parser::new(),
     };
-    h.write_all(&bytes).unwrap();
-    let mut html = Vec::new();
-    h.renderer.emit_html(&mut html).unwrap();
+    handle.write_all(&bytes).unwrap();
+    handle.renderer.emit_html().unwrap();
+
     let mut css = Vec::new();
-    h.renderer.emit_css(&mut css).unwrap();
+    handle.renderer.out = &mut css;
+    handle.renderer.emit_css().unwrap();
 
     (
         String::from_utf8(css).unwrap(),

--- a/ansi-to-html/src/main.rs
+++ b/ansi-to-html/src/main.rs
@@ -1,8 +1,9 @@
-use std::io::{copy, stdin, stdout};
+use std::io::{copy, stdin, stdout, BufWriter};
 
 fn main() {
     env_logger::init();
-    let mut handle = ansi_to_html::Handle::new();
+    let out = BufWriter::new(stdout().lock());
+    let mut handle = ansi_to_html::Handle::new(out);
     copy(&mut stdin().lock(), &mut handle).unwrap();
-    handle.finish(stdout().lock()).unwrap();
+    handle.finish().unwrap()
 }

--- a/ansi-to-html/src/perform.rs
+++ b/ansi-to-html/src/perform.rs
@@ -1,8 +1,9 @@
 use crate::ansi::{Color, C0};
 use crate::renderer::Renderer;
+use std::io::Write;
 use vte::{Params, ParamsIter, Perform};
 
-impl Perform for Renderer {
+impl<W: Write> Perform for Renderer<W> {
     fn print(&mut self, c: char) {
         self.print(c);
     }
@@ -170,6 +171,7 @@ impl Perform for Renderer {
     }
 }
 
+#[inline]
 fn parse_color(it: &mut ParamsIter) -> Option<Color> {
     match it.next() {
         Some(&[5]) => {

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -124,6 +124,7 @@ async fn sync_all_html(client: Arc<Client>) -> Result<Vec<Crate>> {
             }
             */
 
+            log::info!("Rendering {:?}", krate);
             let rendered = render::render_crate(&krate, &raw);
             /*
             let mut header = tar::Header::new_gnu();


### PR DESCRIPTION
The current implementation buffers the entire rendering state in memory, which causes the rendering process to require unbounded memory use.

This change makes us simulate a reasonable rendering area, and any rows pushed off the top are output immediately. This *dramatically* reduces the memory usage of rendering on-the-fly.