### PR TITLE
Make rendering deterministic, ignore 2 bad crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -31,6 +31,7 @@ name = "ansi-to-html"
 version = "0.1.0"
 dependencies = [
  "env_logger",
+ "fnv",
  "log",
  "vte",
 ]

--- a/ansi-to-html/Cargo.lock
+++ b/ansi-to-html/Cargo.lock
@@ -7,6 +7,7 @@ name = "ansi-to-html"
 version = "0.1.0"
 dependencies = [
  "env_logger",
+ "fnv",
  "log",
  "vte",
 ]
@@ -25,6 +26,12 @@ checksum = "85cdab6a89accf66733ad5a1693a4dcced6aeff64602b634530dd73c1f3ee9f0"
 dependencies = [
  "log",
 ]
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "log"

--- a/ansi-to-html/Cargo.toml
+++ b/ansi-to-html/Cargo.toml
@@ -5,5 +5,6 @@ edition = "2021"
 
 [dependencies]
 env_logger = { version = "0.10.0", default-features = false }
+fnv = "1.0.7"
 log = "0.4.17"
 vte = "0.11.0"

--- a/ansi-to-html/src/renderer.rs
+++ b/ansi-to-html/src/renderer.rs
@@ -1,8 +1,8 @@
 use crate::ansi::Color;
 use std::cell::RefCell;
-use std::collections::HashMap;
 use std::collections::VecDeque;
 use std::io::Write;
+use fnv::FnvHashMap as HashMap;
 
 // This is the number of rows that inapty uses, should be good enough?
 const MAX_ROWS: usize = 64;

--- a/src/run.rs
+++ b/src/run.rs
@@ -17,7 +17,12 @@ use uuid::Uuid;
 static TEST_END_DELIMITER: Lazy<Uuid> = Lazy::new(Uuid::new_v4);
 
 // These crates generate gigabytes of output then don't build.
-const IGNORED_CRATES: &[&str] = &["clacks_mtproto", "stdweb", "wayland-raw-protocol-bindings", "pleingres"];
+const IGNORED_CRATES: &[&str] = &[
+    "clacks_mtproto",
+    "stdweb",
+    "wayland-raw-protocol-bindings",
+    "pleingres",
+];
 
 #[derive(Parser, Clone)]
 pub struct Args {

--- a/src/run.rs
+++ b/src/run.rs
@@ -17,7 +17,7 @@ use uuid::Uuid;
 static TEST_END_DELIMITER: Lazy<Uuid> = Lazy::new(Uuid::new_v4);
 
 // These crates generate gigabytes of output then don't build.
-const IGNORED_CRATES: &[&str] = &["clacks_mtproto", "stdweb"];
+const IGNORED_CRATES: &[&str] = &["clacks_mtproto", "stdweb", "wayland-raw-protocol-bindings", "pleingres"];
 
 #[derive(Parser, Clone)]
 pub struct Args {


### PR DESCRIPTION
We prevent re-uploading unchanged HTML because reads are much cheaper than writes.

But the check wasn't doing anything because the order of the CSS elements was nondeterministic :facepalm: 